### PR TITLE
修复gzip和httpContent分段问题

### DIFF
--- a/src/main/java/lee/study/proxyee/handler/HttpProxyInitializer.java
+++ b/src/main/java/lee/study/proxyee/handler/HttpProxyInitializer.java
@@ -36,6 +36,9 @@ public class HttpProxyInitializer extends ChannelInitializer {
               .newHandler(ch.alloc(), requestProto.getHost(), requestProto.getPort()));
     }
     ch.pipeline().addLast("httpCodec", new HttpClientCodec());
+    ch.pipeline().addLast("aggegator", new HttpObjectAggregator(Integer.MAX_VALUE));
+		ch.pipeline().addLast("httpContentDecompressor", new HttpContentDecompressor());
     ch.pipeline().addLast("proxyClientHandle", new HttpProxyClientHandle(clientChannel));
+    ch.pipeline().addLast("httpContentCompressor", new HttpContentCompressor());
   }
 }


### PR DESCRIPTION
添加httpContentDecompressor,修复代理启用了gzip压缩的网站时在afterResponse方法获取到的httpContent为压缩之后的数据,不方便修改的问题;添加httpContentCompressor修复客户端请求头包含Accept-Encoding: gzip时若afterResponse返回未经过gzip压缩的数据导致部分客户端异常bug;添加aggegator对httpContent进行聚合,修复一个http请求回调好几次afterResponse方法,每次在afterResponse获取到的httpContent为完整httpContent的部分数据,导致在afterResponse不方便修改返回给客户端的数据问题