### PR TITLE
Channel复用导致代理请求返回异常的问题

### DIFF
--- a/src/main/java/com/github/monkeywie/proxyee/exception/HttpProxyExceptionHandle.java
+++ b/src/main/java/com/github/monkeywie/proxyee/exception/HttpProxyExceptionHandle.java
@@ -1,6 +1,14 @@
 package com.github.monkeywie.proxyee.exception;
 
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 
 public class HttpProxyExceptionHandle {
 
@@ -10,6 +18,31 @@ public class HttpProxyExceptionHandle {
 
     public void afterCatch(Channel clientChannel, Channel proxyChannel, Throwable cause)
             throws Exception {
-        throw new Exception(cause);
+
+        ByteArrayOutputStream baos = null;
+
+        try {
+
+            baos = new ByteArrayOutputStream();
+            PrintStream printStream = new PrintStream(baos);
+            cause.printStackTrace(printStream);
+
+            ByteBuf byteBuf = clientChannel.alloc().heapBuffer(baos.size());
+            byteBuf.writeBytes(baos.toByteArray());
+
+            HttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,
+                    HttpResponseStatus.BAD_GATEWAY,byteBuf);
+            clientChannel.writeAndFlush(response);
+            if (clientChannel.pipeline().get("httpCodec") != null) {
+                clientChannel.pipeline().remove("httpCodec");
+            }
+
+        } finally {
+
+            if (baos != null) {
+                baos.close();
+            }
+
+        }
     }
 }

--- a/src/main/java/com/github/monkeywie/proxyee/handler/HttpProxyClientHandle.java
+++ b/src/main/java/com/github/monkeywie/proxyee/handler/HttpProxyClientHandle.java
@@ -7,6 +7,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.LastHttpContent;
 import io.netty.util.ReferenceCountUtil;
 
 public class HttpProxyClientHandle extends ChannelInboundHandlerAdapter {
@@ -28,6 +29,10 @@ public class HttpProxyClientHandle extends ChannelInboundHandlerAdapter {
                 .get("serverHandle")).getInterceptPipeline();
         if (msg instanceof HttpResponse) {
             interceptPipeline.afterResponse(clientChannel, ctx.channel(), (HttpResponse) msg);
+        } else if (msg instanceof LastHttpContent) {
+            clientChannel.writeAndFlush(msg);
+            ctx.close().sync();
+            clientChannel.close().sync();
         } else if (msg instanceof HttpContent) {
             interceptPipeline.afterResponse(clientChannel, ctx.channel(), (HttpContent) msg);
         } else {


### PR DESCRIPTION
monkey wie大佬好，
        使用proxyee作为代理服务器来进行使用的时候发现一个问题。
        当我请求一个http协议的A地址的时，请求完毕之后，proxyee没有主动关闭clientchannel（用户端->proxyee）以及proxychannel(proxyee->http://A)。
        这个时候,我如果马上请求一个http协议的B地址的时候，有可能就会复用上一个请求A时的clientchannel和proxychannel。导致请求B地址的返回内容和我期望的不一致（失败了）。
        上述场景使用jmeter进行压力测试能比较容易复现出来。
        针对上述场景，如果要及时关闭channel的话，需要在HttpProxyClientHandle的channelRead方法中，对proxychannel读取的msg进行判断，如果msg是LastHttpContent的话，就表示这次HttpResponse已经完整（结束）了，这个时候就可以手动关闭clientchannel和proxychannel。我提交了个pr，希望monkey wie大佬能不能康康（如果能通过那就更好了 XD）。
        PS:当我请求一个https协议的地址的时候，貌似没有以上的问题，看代码中https请求转发的时候用的是TunnelProxyInitializer创建的pipeline。clientchannel和proxychannel都及时关闭了。这个我没搞懂是为什么。不是很熟https协议2333。
        PPS:还发现一个问题，在使用的过程中，其实我还需要配置二级代理，当二级代理连接不成功的时候，proxychannel中会抛出异常，但是抛出异常时，我在用户端却收不到对应的异常消息，并没有HttpResponse返回。查看代码发现不管目标服务是http还是https协议，,proxychannel中抛出的异常都是由clientchannel中的HttpProxyExceptionHandle来处理，但是实际上HttpProxyExceptionHandle的实现特别简单，只是直接把异常抛出。所以我也修改了下HttpProxyExceptionHandle。可以解决访问http协议目标服务时，将proxychannel中的异常返回给用户端。（但是访问https协议目标服务时，还是无法返回异常给用户端。。。。再一次不是很熟https协议2333）。
