### PR TITLE
调整 CertDownIntercept 以允许自行设置 CA 证书.

### DIFF
--- a/src/main/java/com/github/monkeywie/proxyee/intercept/common/CertDownIntercept.java
+++ b/src/main/java/com/github/monkeywie/proxyee/intercept/common/CertDownIntercept.java
@@ -3,12 +3,14 @@ package com.github.monkeywie.proxyee.intercept.common;
 import com.github.monkeywie.proxyee.crt.CertUtil;
 import com.github.monkeywie.proxyee.intercept.HttpProxyIntercept;
 import com.github.monkeywie.proxyee.intercept.HttpProxyInterceptPipeline;
+import com.github.monkeywie.proxyee.server.HttpProxyCACertFactory;
 import com.github.monkeywie.proxyee.util.ProtoUtil;
 import com.github.monkeywie.proxyee.util.ProtoUtil.RequestProto;
 import io.netty.channel.Channel;
 import io.netty.handler.codec.http.*;
 
 import java.net.InetSocketAddress;
+import java.security.cert.X509Certificate;
 
 /**
  * 处理证书下载页面 http://proxyServerIp:proxyServerPort
@@ -16,6 +18,18 @@ import java.net.InetSocketAddress;
 public class CertDownIntercept extends HttpProxyIntercept {
 
     private boolean crtFlag = false;
+
+    private X509Certificate cert = null;
+
+    public CertDownIntercept() {}
+
+    public CertDownIntercept(HttpProxyCACertFactory certFactory) throws Exception {
+        this.cert = certFactory.getCACert();
+    }
+
+    public CertDownIntercept(X509Certificate caCert) {
+        this.cert = caCert;
+    }
 
     @Override
     public void beforeRequest(Channel clientChannel, HttpRequest httpRequest,
@@ -32,9 +46,12 @@ public class CertDownIntercept extends HttpProxyIntercept {
             if (httpRequest.uri().matches("^.*/ca.crt.*$")) {  //下载证书
                 HttpResponse httpResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1,
                         HttpResponseStatus.OK);
-                byte[] bts = CertUtil
-                        .loadCert(Thread.currentThread().getContextClassLoader().getResourceAsStream("ca.crt"))
-                        .getEncoded();
+
+                byte[] bts = this.cert == null ? CertUtil
+                .loadCert(Thread.currentThread().getContextClassLoader().getResourceAsStream("ca.crt"))
+                .getEncoded() :
+                cert.getEncoded();
+
                 httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "application/x-x509-ca-cert");
                 httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, bts.length);
                 httpResponse.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);

--- a/src/main/java/com/github/monkeywie/proxyee/intercept/common/CertDownIntercept.java
+++ b/src/main/java/com/github/monkeywie/proxyee/intercept/common/CertDownIntercept.java
@@ -21,12 +21,28 @@ public class CertDownIntercept extends HttpProxyIntercept {
 
     private X509Certificate cert = null;
 
+    /**
+     * Using proxyee's own CA certificate to construct CertDownIntercept
+     */
     public CertDownIntercept() {}
 
+    /**
+     * Using CA public key in {@linkplain HttpProxyCACertFactory CaCertFactory} to construct CertDownIntercept
+     * <p> Visitors will receive a CA certificate from CaCertFactory instead of proxyee's built-in certificate.
+     * @param certFactory The same factory as {@link com.github.monkeywie.proxyee.server.HttpProxyServer}
+     *                    ({@link com.github.monkeywie.proxyee.server.HttpProxyServer#caCertFactory(HttpProxyCACertFactory)})
+     *                    is required, otherwise HTTP processing will fail
+     * @throws Exception When factory throws an exception, it will be thrown directly.
+     */
     public CertDownIntercept(HttpProxyCACertFactory certFactory) throws Exception {
         this.cert = certFactory.getCACert();
     }
 
+    /**
+     * Provide certificate structure CertDownIntercept directly.
+     * @param caCert The public key of CA certificate consistent with 
+     *               {@link com.github.monkeywie.proxyee.server.HttpProxyServer}.
+     */
     public CertDownIntercept(X509Certificate caCert) {
         this.cert = caCert;
     }


### PR DESCRIPTION
通过 `CertDownIntercept` 这个调整，可以允许开发者设置自己的（或者动态生成）CA 证书以降低（甚至是消除）由于使用 proxyee 自带证书而造成的潜在风险。

> 不过由于 `HttpProxyServer` 的设计，最好使用 HttpProxyCACertFactory 为 `CertDownIntercept` 提供证书.