### PR TITLE
Add HttpProxyAuthenticationProvider.authenticate(HttpRequest request)

### DIFF
--- a/src/main/java/com/github/monkeywie/proxyee/handler/HttpProxyServerHandler.java
+++ b/src/main/java/com/github/monkeywie/proxyee/handler/HttpProxyServerHandler.java
@@ -154,7 +154,13 @@ public class HttpProxyServerHandler extends ChannelInboundHandlerAdapter {
     private boolean authenticate(ChannelHandlerContext ctx, HttpRequest request) {
         if (serverConfig.getAuthenticationProvider() != null) {
             HttpProxyAuthenticationProvider authProvider = serverConfig.getAuthenticationProvider();
-            HttpToken httpToken = authProvider.authenticate(request.headers().get(HttpHeaderNames.PROXY_AUTHORIZATION));
+
+            // Disable auth for request?
+            if (!authProvider.matches(request)) {
+                return true;
+            }
+
+            HttpToken httpToken = authProvider.authenticate(request);
             if (httpToken == null) {
                 HttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpProxyServer.UNAUTHORIZED);
                 response.headers().set(HttpHeaderNames.PROXY_AUTHENTICATE, authProvider.authType() + " realm=\"" + authProvider.authRealm() + "\"");

--- a/src/main/java/com/github/monkeywie/proxyee/server/auth/HttpProxyAuthenticationProvider.java
+++ b/src/main/java/com/github/monkeywie/proxyee/server/auth/HttpProxyAuthenticationProvider.java
@@ -1,6 +1,8 @@
 package com.github.monkeywie.proxyee.server.auth;
 
 import com.github.monkeywie.proxyee.server.auth.model.HttpToken;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpRequest;
 
 /**
  * @Author LiWei
@@ -13,4 +15,12 @@ public interface HttpProxyAuthenticationProvider<R extends HttpToken> {
     String authRealm();
 
     R authenticate(String authorization);
+
+    default R authenticate(HttpRequest request) {
+      return authenticate(request.headers().get(HttpHeaderNames.PROXY_AUTHORIZATION));
+    }
+
+    default boolean matches(HttpRequest request) {
+        return true;
+    }
 }

--- a/src/test/java/com/github/monkeywie/proxyee/AuthHttpProxyServer.java
+++ b/src/test/java/com/github/monkeywie/proxyee/AuthHttpProxyServer.java
@@ -8,11 +8,16 @@ import com.github.monkeywie.proxyee.server.HttpProxyServerConfig;
 import com.github.monkeywie.proxyee.server.auth.BasicHttpProxyAuthenticationProvider;
 import com.github.monkeywie.proxyee.server.auth.HttpAuthContext;
 import com.github.monkeywie.proxyee.server.auth.model.BasicHttpToken;
+import com.github.monkeywie.proxyee.util.ProtoUtil.RequestProto;
 import io.netty.channel.Channel;
+import io.netty.handler.codec.http.*;
+
+import java.nio.charset.StandardCharsets;
 
 public class AuthHttpProxyServer {
 
     // curl -i -x 127.0.0.1:9999 -U admin:123456 https://www.baidu.com
+    // curl -v http://127.0.0.1:9999/status/health
     public static void main(String[] args) throws Exception {
         HttpProxyServerConfig config = new HttpProxyServerConfig();
         config.setAuthenticationProvider(new BasicHttpProxyAuthenticationProvider() {
@@ -23,12 +28,54 @@ public class AuthHttpProxyServer {
                 }
                 return null;
             }
+
+            @Override
+            public boolean matches(HttpRequest request) {
+                if (request.uri().matches("^/status/health$")) {
+                    return false;
+                }
+                return true;
+            }
         });
         new HttpProxyServer()
                 .serverConfig(config)
                 .proxyInterceptInitializer(new HttpProxyInterceptInitializer() {
                     @Override
                     public void init(HttpProxyInterceptPipeline pipeline) {
+                        pipeline.addLast(new HttpProxyIntercept() {
+                            private boolean isDirect = false;
+
+                            @Override
+                            public void beforeRequest(Channel clientChannel, HttpRequest httpRequest, HttpProxyInterceptPipeline pipeline) throws Exception {
+                                RequestProto requestProto = pipeline.getRequestProto();
+                                if (!requestProto.getProxy() && httpRequest.uri().matches("^/status/health$")) {
+                                    isDirect = true;
+
+                                    HttpResponse httpResponse = new DefaultHttpResponse(HttpVersion.HTTP_1_1,
+                                            HttpResponseStatus.OK);
+
+                                    String res = "OK";
+                                    byte[] bts = res.getBytes(StandardCharsets.UTF_8);
+
+                                    httpResponse.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/plain;charset=utf-8");
+                                    httpResponse.headers().set(HttpHeaderNames.CONTENT_LENGTH, bts.length);
+                                    httpResponse.headers().set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE);
+                                    HttpContent httpContent = new DefaultLastHttpContent();
+                                    httpContent.content().writeBytes(bts);
+                                    clientChannel.writeAndFlush(httpResponse);
+                                    clientChannel.writeAndFlush(httpContent);
+                                    clientChannel.close();
+                                }
+
+                            }
+
+                            @Override
+                            public void beforeRequest(Channel clientChannel, HttpContent httpContent, HttpProxyInterceptPipeline pipeline) throws Exception {
+                                if (!isDirect) pipeline.beforeRequest(clientChannel, httpContent);
+                            }
+                        });
+
+
                         pipeline.addLast(new HttpProxyIntercept() {
                             @Override
                             public void beforeConnect(Channel clientChannel, HttpProxyInterceptPipeline pipeline) throws Exception {


### PR DESCRIPTION
This should be binary compatible. 

    * Add HttpProxyAuthenticationProvider.authenticate(HttpRequest request)
    * Add HttpProxyAuthenticationProvider.matches(HttpRequest request)
    * Update test/AuthHttpProxyServer.java to include test

Motivation:  I created a healthcheck intercept (https://gist.github.com/er1c/84a530af018f6c620421a9a20371d96e) and I want to have a different set (or none at all) of credentials that only apply to a specific uri (e.g. `/status/health`)

`HttpProxyAuthenticationProvider.authenticate(HttpRequest)` allows having different credentials based upon request properties (e.g. `uri`)

`HttpProxyAuthenticationProvider.matches(HttpRequest)` allows disabling authentication for specific request properties (e.g. `uri`)

This should also allow  implementing a `HttpProxyAuthenticationProvider` that allows filtering based upon other properties in the HttpRequest (e.g. `HeaderNames.AUTHORIZATION`)