### PR TITLE
[#220] Respond with a bad server status on DecoderExceptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.monkeywie</groupId>
     <artifactId>proxyee</artifactId>
-    <version>1.6.5</version>
+    <version>1.6.6-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 
@@ -38,7 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <netty.version>4.1.71.Final</netty.version>
+        <netty.version>4.1.78.Final</netty.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Addresses #220 

```
WxsIiwib3JpZ2luYXRvcjphZG1pbjp3cml0ZSIsInN2Yy1sZWFkOmxlYWRzOmluc2VydC10ZXN0IiwiYW5hbHl0aWNzOnJldmVudWU6cmVhZEFsbCIsInN2Yy1sZWFkOmxlYWRBY3Rpb25zOmluc2VydCJdfQ.eBkhD5L6ZpzRE2_7aH4P3yR9aeVhIWm9UZC5_kNcRcHTqQo6kH6ka8VAsPAYSNfve6MoNAA4OadrdmnnUBEZUV6TtHZ27g5D81u0u_erETprzJotn55HsAgugaN574vvCQK-8UWhDyOIce21oDgJ_v-AEnoAJLHxQTV5wAhlPgITnCmMajKxtKA-b67lHzH7BEUfo8yld_ax_Q7eW6XQ5lGYIDbuKOadXK5BqB-Zgwew0iTljjL-_zW9ViOE6k_jJ3k3wjM_-t3CVhgEjRdcMaj7fw2QBSPDIApZW-P7qj5XeJ2N11gOyUby7LqWBmlxf9tCVqzZqDKAMBUqzFju1g
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 431 Request Header Fields Too Large
* no chunk, no close, no size. Assume close to signal end
```

I'm unsure if the `ctx.channel().pipeline().remove("httpCodec");` is required.