### PR TITLE
修复http进行认证时输入空账号空密码后索引越界导致无法继续弹窗认证的问题

### DIFF
--- a/src/main/java/com/github/monkeywie/proxyee/server/auth/BasicHttpProxyAuthenticationProvider.java
+++ b/src/main/java/com/github/monkeywie/proxyee/server/auth/BasicHttpProxyAuthenticationProvider.java
@@ -31,7 +31,9 @@ public abstract class BasicHttpProxyAuthenticationProvider implements HttpProxyA
             String token = authorization.substring(AUTH_TYPE_BASIC.length() + 1);
             String decode = new String(Base64.getDecoder().decode(token));
             String[] arr = decode.split(":");
-            usr = arr[0];
+            if (arr.length >= 1) {
+                usr = arr[0];
+            }
             if (arr.length >= 2) {
                 pwd = arr[1];
             }


### PR DESCRIPTION
修复http进行认证时输入空账号空密码后索引越界导致无法继续弹窗认证的问题