### PR TITLE
fix(sec): upgrade io.netty:netty-codec-http to 4.1.86.final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <netty.version>4.1.86.Final</netty.version>
+        <netty.version>4.1.86.final</netty.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.netty:netty-codec-http 4.1.86.Final
- [CVE-2022-41915](https://www.oscs1024.com/hd/CVE-2022-41915)


### What did I do？
Upgrade io.netty:netty-codec-http from 4.1.86.Final to 4.1.86.final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS