### PR TITLE
feat: support user defined ChannelFactory and forseResolveDNS

### DIFF
--- a/src/main/java/com/github/monkeywie/proxyee/handler/HttpProxyServerHandler.java
+++ b/src/main/java/com/github/monkeywie/proxyee/handler/HttpProxyServerHandler.java
@@ -336,9 +336,9 @@ public class HttpProxyServerHandler extends ChannelInboundHandlerAdapter {
                     : new TunnelProxyInitializer(channel, proxyHandler);
             Bootstrap bootstrap = new Bootstrap();
             bootstrap.group(getServerConfig().getProxyLoopGroup()) // 注册线程池
-                    .channel(NioSocketChannel.class) // 使用NioSocketChannel来作为连接用的channel类
+                    .channelFactory(getServerConfig().getChannelFactory())
                     .handler(channelInitializer);
-            if (proxyHandler != null) {
+            if (proxyHandler != null && !getServerConfig().getForceResolveDNS()) {
                 // 代理服务器解析DNS和连接
                 bootstrap.resolver(NoopAddressResolverGroup.INSTANCE);
             } else {

--- a/src/main/java/com/github/monkeywie/proxyee/server/HttpProxyServerConfig.java
+++ b/src/main/java/com/github/monkeywie/proxyee/server/HttpProxyServerConfig.java
@@ -4,7 +4,11 @@ import com.github.monkeywie.proxyee.server.accept.HttpProxyAcceptHandler;
 import com.github.monkeywie.proxyee.server.accept.HttpProxyMitmMatcher;
 import com.github.monkeywie.proxyee.server.auth.HttpProxyAuthenticationProvider;
 import com.github.monkeywie.proxyee.config.IdleStateCheck;
+
+import io.netty.channel.ChannelFactory;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.HttpObjectDecoder;
 import io.netty.handler.ssl.SslContext;
 import io.netty.resolver.AddressResolverGroup;
@@ -37,6 +41,8 @@ public class HttpProxyServerConfig {
     private int maxHeaderSize = HttpObjectDecoder.DEFAULT_MAX_HEADER_SIZE;
     private int maxChunkSize = HttpObjectDecoder.DEFAULT_MAX_CHUNK_SIZE;
     private IdleStateCheck idleStateCheck;
+    private ChannelFactory<SocketChannel> channelFactory;
+    private boolean forceResolveDNS = false;
 
     public HttpProxyServerConfig() {
         this(DefaultAddressResolverGroup.INSTANCE);
@@ -65,6 +71,30 @@ public class HttpProxyServerConfig {
         this.maxHeaderSize = builder.maxHeaderSize;
         this.maxChunkSize = builder.maxChunkSize;
         this.idleStateCheck = builder.idleStateCheck;
+    }
+
+    public void setForceResolveDNS(boolean forceResolveDNS) {
+        this.forceResolveDNS = forceResolveDNS;
+    }
+
+    public boolean getForceResolveDNS() {
+        return forceResolveDNS;
+    }
+
+    public ChannelFactory<SocketChannel> getChannelFactory() {
+        if (channelFactory == null) {
+            return (new ChannelFactory<SocketChannel>() {
+                @Override
+                public SocketChannel newChannel() {
+                    return new NioSocketChannel(); // 使用NioSocketChannel来作为连接用的channel类
+                }
+            });
+        }
+        return channelFactory;
+    }
+
+    public void setChannelFactory(ChannelFactory<SocketChannel> channelFactory) {
+        this.channelFactory = channelFactory;
     }
 
     public SslContext getClientSslCtx() {


### PR DESCRIPTION
We need to do like this while writing Android VPN Service to protect our socket connection:
``` kotlin
val javaNioChannel = SelectorProvider.provider().openSocketChannel()
val res = protect(javaNioChannel.socket())
```
In addition, VPN services also proxy DNS requests, so we need to directly connect to the DNS server within the proxy server
``` kotlin
val dnsResolverGroup = object : DnsAddressResolverGroup(
            DnsNameResolverBuilder()
                .apply {
                    nameServerProvider(
                        SingletonDnsServerAddressStreamProvider(
                            InetSocketAddress("114.114.114.114", 53)
                        )
                    )
                    channelType(NioDatagramChannel::class.java)
                    queryTimeoutMillis(5000)
                    maxQueriesPerResolve(3)
                }
        ) {}
```